### PR TITLE
Change "Shortest route" badge's position

### DIFF
--- a/templates/results_by_stage.html
+++ b/templates/results_by_stage.html
@@ -57,6 +57,9 @@ $(function () {
 .listview li {
     width:350px;
 }
+.listview li div.badge{
+    left: 130px !important;
+}
 {% endblock %}
 
 


### PR DESCRIPTION
The shortest route badge looks better in the center. In its current position it overlaps the bus icon and the bus number, which does not look pretty.